### PR TITLE
Fix out-of-bounds errors in Mesh::initInvMap().

### DIFF
--- a/src/Mesh.cc
+++ b/src/Mesh.cc
@@ -273,18 +273,20 @@ void Mesh::initInvMap() {
     sort(pcpair.begin(), pcpair.end());
     for (int i = 0; i < numc; ++i) {
         int p = pcpair[i].first;
-        int pp = pcpair[i+1].first;
-        int pm = pcpair[i-1].first;
         int c = pcpair[i].second;
-        int cp = pcpair[i+1].second;
 
-        if (i == 0 || p != pm)  mappcfirst[p] = c;
-        if (i+1 == numc || p != pp)
-            mapccnext[c] = -1;
-        else
-            mapccnext[c] = cp;
+        if (i == 0) mappcfirst[p] = c;
+        else {
+            int pm = pcpair[i-1].first;
+            if (p != pm) mappcfirst[p] = c;
+        }
+        mapccnext[c] = -1;
+        if (i+1 != numc) {
+            int pp = pcpair[i+1].first;
+            int cp = pcpair[i+1].second;
+            if (p == pp) mapccnext[c] = cp;
+        }
     }
-
 }
 
 


### PR DESCRIPTION
I've put together a small fix that appears to fix the out-of-bounds errors. I conducted some rudimentary testing on my end, and this update appears to also produce expected results.